### PR TITLE
D-161225: Update dependabot + helm --atomic flag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,11 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "github-actions"
       - "ci-skippush"
   - package-ecosystem: "docker"
-    directory: "/whoami"
-    schedule:
-      interval: "daily"
-    labels:
-      - "ci-skippush"
-  - package-ecosystem: "docker"
-    directory: "/gha-runner"
+    directories: 
+      - "/apps/whoami"
+      - "/images/gha-runner"
     schedule:
       interval: "daily"
     labels:

--- a/.github/workflows/rw-cd.yaml
+++ b/.github/workflows/rw-cd.yaml
@@ -45,7 +45,7 @@ jobs:
         sed -i "s/^name: .*/name: ${{ steps.set_app_name.outputs.app_name }}/" .helm-tmpl/Chart.yaml
         sed -i "s/^appVersion: .*/appVersion: ${{ inputs.tag }}/" .helm-tmpl/Chart.yaml
 
-        helm upgrade --install --atomic \
+        helm upgrade --install --rollback-on-failure \
           --create-namespace \
           --namespace ${{ steps.set_app_name.outputs.app_name }} \
           --set image.repository=${{ secrets.DOCKER_USERNAME }}/${{ steps.set_app_name.outputs.app_name }} \


### PR DESCRIPTION
1. Update dependabot.yaml to support multiple directories
2. Flag --atomic has been deprecated, use --rollback-on-failure instead 